### PR TITLE
feat(api): cerrar fase 7 de DRF multi-org

### DIFF
--- a/apis/client/views.py
+++ b/apis/client/views.py
@@ -1,11 +1,31 @@
 from .serializers import AddressSerializer, ClientSerializer
 from client.models import Client, Address
+from client.selectors import get_client_by_pk
+from rest_framework.response import Response
+from rest_framework import status
 from rest_framework import viewsets
+
 
 class AddressViewSet(viewsets.ModelViewSet):
     queryset = Address.objects.all()
     serializer_class = AddressSerializer
 
+
 class ClientViewSet(viewsets.ModelViewSet):
-    queryset = Client.objects.all()
+    queryset = Client.objects.none()
     serializer_class = ClientSerializer
+
+    def list(self, request, *args, **kwargs):
+        return Response(
+            {"detail": "client detail endpoint only"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    def retrieve(self, request, *args, **kwargs):
+        try:
+            client = get_client_by_pk(client_id=kwargs['pk'])
+        except Client.DoesNotExist:
+            return Response({"detail": "Not Found"}, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = self.get_serializer(client)
+        return Response(serializer.data)

--- a/apis/employee/serializers.py
+++ b/apis/employee/serializers.py
@@ -1,7 +1,20 @@
 from employee.models import Employee
 from rest_framework import serializers
 
+
 class EmployeeSerializer(serializers.ModelSerializer):
+    organization_id = serializers.IntegerField(source='organization.id', read_only=True)
+    organization_slug = serializers.CharField(source='organization.slug', read_only=True)
+
     class Meta:
         model = Employee
-        fields = '__all__'
+        fields = [
+            'id',
+            'first_name',
+            'last_name',
+            'phone_number',
+            'chat_id',
+            'organization_id',
+            'organization_slug',
+        ]
+        read_only_fields = ['organization_id', 'organization_slug']

--- a/apis/employee/views.py
+++ b/apis/employee/views.py
@@ -1,30 +1,60 @@
 from employee.models import Employee
+from employee.selectors import (
+    get_employee_by_chat_id,
+    get_employee_by_phone,
+    get_employee_by_pk,
+)
+from employee.services import employee_update_chat_id
 from .serializers import EmployeeSerializer
 from rest_framework.response import Response
 from rest_framework import viewsets, status
 
 
 class EmployeeViewSet(viewsets.ModelViewSet):
-    queryset = Employee.objects.all()
+    queryset = Employee.objects.none()
     serializer_class = EmployeeSerializer
 
     def list(self, request, *args, **kwargs):
         phone_number = request.query_params.get('phone_number', None)
         chat_id = request.query_params.get('chat_id', None)
-        if phone_number:
-            queryset = self.get_queryset().filter(phone_number=phone_number)
-        elif chat_id:
-            queryset = self.get_queryset().filter(chat_id=chat_id)
-        else:
-            queryset = self.get_queryset()
-
-        if not queryset.exists():
+        try:
+            if chat_id:
+                employee = get_employee_by_chat_id(chat_id=chat_id)
+            elif phone_number:
+                employee = get_employee_by_phone(phone_number=phone_number[-10:])
+            else:
+                return Response(
+                    {"detail": "chat_id or phone_number is required"},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+        except Employee.DoesNotExist:
             return Response({"detail": "Not Found"}, status=status.HTTP_404_NOT_FOUND)
 
-        if phone_number or chat_id:
-            serializer = self.get_serializer(queryset.first())
-            return Response(serializer.data)
-        serializer = self.get_serializer(queryset, many=True)
-
+        serializer = self.get_serializer(employee)
         return Response(serializer.data)
 
+    def retrieve(self, request, *args, **kwargs):
+        try:
+            employee = get_employee_by_pk(employee_id=kwargs['pk'])
+        except Employee.DoesNotExist:
+            return Response({"detail": "Not Found"}, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = self.get_serializer(employee)
+        return Response(serializer.data)
+
+    def update(self, request, *args, **kwargs):
+        chat_id = request.data.get('chat_id')
+        if chat_id is None:
+            return Response(
+                {"chat_id": ["This field is required."]},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            employee = get_employee_by_pk(employee_id=kwargs['pk'])
+        except Employee.DoesNotExist:
+            return Response({"detail": "Not Found"}, status=status.HTTP_404_NOT_FOUND)
+
+        employee = employee_update_chat_id(employee=employee, chat_id=str(chat_id))
+        serializer = self.get_serializer(employee)
+        return Response(serializer.data)

--- a/apis/service/views.py
+++ b/apis/service/views.py
@@ -2,34 +2,50 @@ from rest_framework.response import Response
 
 from .serializers import ServiceSerializer, ServiceUpdateSerializer
 from service.models import Service
+from service.selectors import get_service_by_pk
+from service.services import service_update_from_api
 from rest_framework import viewsets
 
+
 class ServiceViewSet(viewsets.ModelViewSet):
-    queryset = Service.objects.all()
+    queryset = Service.objects.none()
     serializer_class = ServiceSerializer
 
+    def retrieve(self, request, *args, **kwargs):
+        try:
+            service = get_service_by_pk(service_id=kwargs['pk'])
+        except Service.DoesNotExist:
+            return Response({"detail": "Not Found"}, status=404)
+
+        return Response(ServiceSerializer(service, context={'request': request}).data)
 
     def update(self, request, *args, **kwargs):
-        self.serializer_class = ServiceUpdateSerializer
-        return super().update(request, *args, **kwargs)
+        try:
+            service = get_service_by_pk(service_id=kwargs['pk'])
+        except Service.DoesNotExist:
+            return Response({"detail": "Not Found"}, status=404)
 
-    def partial_update(self, request, *args, **kwargs):
-        self.serializer_class = ServiceUpdateSerializer
-        summary = request.data.get('summary')
-        service = self.get_object()
-        if summary:
-            if service.summary:
-                service.summary += f"\n{summary}"
-            else:
-                service.summary = summary
-            service.save(update_fields=["summary"])
-
-        data = request.data.copy()
-        if 'summary' in data:
-            data.pop('summary')
-
-        serializer = self.get_serializer(service, data=data, partial=True)
+        serializer = ServiceUpdateSerializer(service, data=request.data)
         serializer.is_valid(raise_exception=True)
         serializer.save()
+
+        return Response(ServiceSerializer(service, context={'request': request}).data)
+
+    def partial_update(self, request, *args, **kwargs):
+        try:
+            service = get_service_by_pk(service_id=kwargs['pk'])
+        except Service.DoesNotExist:
+            return Response({"detail": "Not Found"}, status=404)
+
+        data = request.data.copy()
+        summary = data.pop('summary', None)
+        serializer = ServiceUpdateSerializer(service, data=data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        service = service_update_from_api(
+            service=service,
+            status=serializer.validated_data.get('status'),
+            end_date=serializer.validated_data.get('end_date'),
+            summary=summary,
+        )
 
         return Response(ServiceSerializer(service, context={'request': request}).data)

--- a/apis/tests.py
+++ b/apis/tests.py
@@ -1,0 +1,147 @@
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from client.models import Client
+from employee.models import Employee
+from organization.models import Organization
+from service.models import Service
+
+
+class EmployeeApiTests(APITestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name="Org API", slug="org-api")
+        self.employee = Employee.objects.create(
+            organization=self.org,
+            first_name="Ana",
+            last_name="Lopez",
+            phone_number="5551234567",
+            chat_id="chat-123",
+        )
+
+    def test_list_by_chat_id_returns_employee_with_organization_context(self):
+        response = self.client.get("/api/employee/", {"chat_id": "chat-123"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], self.employee.id)
+        self.assertEqual(response.data["organization_id"], self.org.id)
+        self.assertEqual(response.data["organization_slug"], self.org.slug)
+
+    def test_list_by_phone_number_uses_last_ten_digits(self):
+        response = self.client.get("/api/employee/", {"phone_number": "5215551234567"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], self.employee.id)
+
+    def test_list_requires_chat_id_or_phone_number(self):
+        response = self.client.get("/api/employee/")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "chat_id or phone_number is required")
+
+    def test_list_returns_404_when_employee_does_not_exist(self):
+        response = self.client.get("/api/employee/", {"chat_id": "missing"})
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"], "Not Found")
+
+    def test_put_updates_only_chat_id_via_service_layer(self):
+        response = self.client.put(
+            f"/api/employee/{self.employee.id}/",
+            {
+                "id": self.employee.id,
+                "first_name": "SHOULD-NOT-CHANGE",
+                "last_name": self.employee.last_name,
+                "phone_number": self.employee.phone_number,
+                "chat_id": "chat-999",
+                "organization_id": self.org.id,
+                "organization_slug": self.org.slug,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.employee.refresh_from_db()
+        self.assertEqual(self.employee.chat_id, "chat-999")
+        self.assertEqual(self.employee.first_name, "Ana")
+        self.assertEqual(response.data["organization_slug"], self.org.slug)
+
+    def test_put_requires_chat_id(self):
+        response = self.client.put(
+            f"/api/employee/{self.employee.id}/",
+            {
+                "id": self.employee.id,
+                "first_name": self.employee.first_name,
+                "last_name": self.employee.last_name,
+                "phone_number": self.employee.phone_number,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["chat_id"], ["This field is required."])
+
+
+class ServiceApiTests(APITestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name="Org Service", slug="org-service")
+        self.client_obj = Client.objects.create(
+            organization=self.org,
+            first_name="Cliente API",
+        )
+        self.service = Service.objects.create(
+            organization=self.org,
+            client=self.client_obj,
+            service_title="Servicio API",
+            service_number=1,
+            summary="Resumen previo",
+        )
+
+    def test_retrieve_returns_service_by_id(self):
+        response = self.client.get(f"/api/service/{self.service.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], self.service.id)
+        self.assertEqual(response.data["service_number"], self.service.service_number)
+
+    def test_patch_appends_summary_and_updates_status(self):
+        response = self.client.patch(
+            f"/api/service/{self.service.id}/",
+            {
+                "status": Service.Status.Cancelled,
+                "summary": "Resumen nuevo",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.service.refresh_from_db()
+        self.assertEqual(self.service.status, Service.Status.Cancelled)
+        self.assertEqual(self.service.summary, "Resumen previo\nResumen nuevo")
+
+    def test_retrieve_returns_404_for_missing_service(self):
+        response = self.client.get("/api/service/9999/")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["detail"], "Not Found")
+
+
+class ClientApiTests(APITestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name="Org Client", slug="org-client")
+        self.client_obj = Client.objects.create(
+            organization=self.org,
+            first_name="Cliente API",
+        )
+
+    def test_retrieve_returns_client_by_id(self):
+        response = self.client.get(f"/api/client/{self.client_obj.id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["id"], self.client_obj.id)
+        self.assertEqual(response.data["first_name"], self.client_obj.first_name)
+
+    def test_list_is_blocked_to_avoid_global_client_exposure(self):
+        response = self.client.get("/api/client/")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "client detail endpoint only")

--- a/client/selectors.py
+++ b/client/selectors.py
@@ -9,5 +9,9 @@ def get_clients_for_org(*, org: Organization) -> QuerySet:
     return Client.objects.filter(organization=org, is_active=True)
 
 
+def get_client_by_pk(*, client_id: int) -> Client:
+    return Client.objects.get(pk=client_id)
+
+
 def get_client_by_id(*, org: Organization, client_id: int) -> Client:
     return Client.objects.get(organization=org, pk=client_id)

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ Este directorio contiene la documentación técnica del proyecto para que cualqu
 | [fase-4-organization-fk.md](./fase-4-organization-fk.md) | Fase 4 — FK `organization` en Employee, Client, Service |
 | [fase-5-selectors-service-layer.md](./fase-5-selectors-service-layer.md) | Fase 5 — Selectors + Service Layer |
 | [fase-6-vistas-web.md](./fase-6-vistas-web.md) | Fase 6 — Vistas web: delgadas, usan selectors + services |
+| [fase-7-api-drf.md](./fase-7-api-drf.md) | Fase 7 — API (DRF): ViewSets usan selectors + services |
 
 ## ¿Cómo usar estos docs?
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,37 @@ Registro de qué se implementó en cada fase y qué verificar antes de continuar
 
 ---
 
+## Fase 7 — API (DRF): ViewSets usan selectors + services
+
+**Fecha:** 2026-04-28
+**Rama:** `feat/fase-7-api-drf`
+
+### Qué se implementó
+
+- `EmployeeViewSet` dejó de consultar ORM directo para bootstrap del bot
+- `GET /api/employee/?chat_id=...` y `GET /api/employee/?phone_number=...` ahora usan selectors
+- `PUT /api/employee/<id>/` ahora actualiza `chat_id` vía `employee_update_chat_id`
+- La respuesta del employee API ahora incluye `organization_id` y `organization_slug`
+- `ServiceViewSet` ya no depende de queryset global abierto para retrieve y mueve el append de `summary` al service layer
+- `ClientViewSet` quedó protegido contra listado global accidental
+- Se agregaron tests DRF para employee, service y client
+
+### Qué probar
+
+```bash
+source .venv/bin/activate
+python manage.py test apis employee client service
+# Debe pasar con los tests de contrato DRF
+
+python manage.py runserver
+# Verificar manualmente:
+# curl "http://localhost:8000/api/employee/?chat_id=123"
+# curl "http://localhost:8000/api/employee/?phone_number=5551234567"
+# curl "http://localhost:8000/api/service/1/"
+```
+
+---
+
 ## Fase 6 — Vistas web: delgadas, usan selectors + services
 
 **Fecha:** 2026-04-28

--- a/docs/fase-7-api-drf.md
+++ b/docs/fase-7-api-drf.md
@@ -1,0 +1,79 @@
+# Fase 7 — API (DRF): ViewSets usan selectors + services
+
+**Fecha:** 2026-04-28
+**Rama:** `feat/fase-7-api-drf`
+
+## Objetivo
+
+Cerrar la migración de DRF al patrón HackSoft: los ViewSets del bot dejan de consultar el ORM directamente y pasan a delegar lecturas y escrituras en `selectors.py` y `services.py`, preparando el aislamiento multi-org para el flujo del bot central.
+
+## Qué se implementó
+
+### Employee API
+
+- `apis/employee/views.py`
+  - `GET /api/employee/?chat_id=...` ahora usa `employee.selectors.get_employee_by_chat_id`
+  - `GET /api/employee/?phone_number=...` ahora usa `employee.selectors.get_employee_by_phone`
+  - `PUT /api/employee/<id>/` actualiza `chat_id` vía `employee.services.employee_update_chat_id`
+  - ya no existe listado global por queryset abierto; si no se envía `chat_id` o `phone_number`, responde `400`
+
+- `apis/employee/serializers.py`
+  - agrega `organization_id`
+  - agrega `organization_slug`
+  - conserva el contrato que necesita el bot para bootstrap y actualización de `chat_id`
+
+### Service API
+
+- `apis/service/views.py`
+  - `GET /api/service/<id>/` ahora usa `service.selectors.get_service_by_pk`
+  - `PATCH /api/service/<id>/` mueve el append de `summary` a `service.services.service_update_from_api`
+  - deja de depender de un queryset global abierto para el flujo actual del bot
+
+### Client API
+
+- `apis/client/views.py`
+  - `GET /api/client/<id>/` ahora usa `client.selectors.get_client_by_pk`
+  - `GET /api/client/` queda bloqueado con `400` para evitar exposición global accidental de clientes
+
+## Archivos modificados
+
+| Archivo | Qué cambió |
+|---------|------------|
+| `apis/employee/views.py` | lookups y update vía selectors/services |
+| `apis/employee/serializers.py` | `organization_id` y `organization_slug` read-only |
+| `apis/service/views.py` | retrieve por selector, partial update apoyado en service layer |
+| `apis/client/views.py` | retrieve por selector, bloqueo de listado global |
+| `employee/selectors.py` | nuevo `get_employee_by_pk` |
+| `service/selectors.py` | nuevo `get_service_by_pk` |
+| `service/services.py` | nuevo `service_update_from_api` |
+| `client/selectors.py` | nuevo `get_client_by_pk` |
+| `apis/tests.py` | tests DRF para employee, service y client |
+| `docs/implementation-plan.md` | checkbox de Fase 7 marcado |
+| `docs/changelog.md` | entrada de Fase 7 agregada |
+| `docs/README.md` | índice actualizado |
+
+## Qué probar
+
+```bash
+source .venv/bin/activate
+
+# Tests de la fase
+python manage.py test apis employee client service
+
+# Verificación manual del contrato usado por el bot
+python manage.py runserver
+
+# En otra terminal:
+curl "http://localhost:8000/api/employee/?chat_id=123"
+curl "http://localhost:8000/api/employee/?phone_number=5551234567"
+curl "http://localhost:8000/api/service/1/"
+```
+
+## Decisiones relevantes
+
+- **D-002:** `GET /api/employee/?chat_id=X` sigue siendo una búsqueda GLOBAL porque ese endpoint hace el bootstrap de autenticación del bot.
+- **D-004:** los ViewSets DRF también deben ser delgados; la lógica de acceso a datos y mutaciones vive en selectors/services.
+
+## Siguiente fase
+
+[Fase 8 — Bot central multi-org](./implementation-plan.md#fase-8--bot-central-multi-org)

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -26,7 +26,7 @@ Si eres un agente retomando este trabajo:
 - [x] Fase 4 — FK `organization` en Employee, Client, Service
 - [x] Fase 5 — Selectors + Service Layer
 - [x] Fase 6 — Vistas web: delgadas, usan selectors + services
-- [ ] Fase 7 — API (DRF): ViewSets usan selectors + services
+- [x] Fase 7 — API (DRF): ViewSets usan selectors + services
 - [ ] Fase 8 — Bot central multi-org
 - [ ] Fase 9 — Panel super-admin para gestión de organizaciones
 

--- a/employee/selectors.py
+++ b/employee/selectors.py
@@ -13,6 +13,10 @@ def get_employee_by_phone(*, phone_number: str) -> Employee:
     return Employee.objects.get(phone_number=phone_number)
 
 
+def get_employee_by_pk(*, employee_id: int) -> Employee:
+    return Employee.objects.get(pk=employee_id)
+
+
 def get_employee_by_id(*, org: Organization, employee_id: int) -> Employee:
     return Employee.objects.get(organization=org, pk=employee_id)
 

--- a/service/selectors.py
+++ b/service/selectors.py
@@ -9,6 +9,10 @@ def get_services_for_org(*, org: Organization) -> QuerySet:
     return Service.objects.filter(organization=org).order_by('-created_at')
 
 
+def get_service_by_pk(*, service_id: int) -> Service:
+    return Service.objects.get(pk=service_id)
+
+
 def get_service_by_id(*, org: Organization, service_id: int) -> Service:
     return Service.objects.get(organization=org, pk=service_id)
 

--- a/service/services.py
+++ b/service/services.py
@@ -71,3 +71,32 @@ def service_reactivate(*, service: Service) -> Service:
     service.employee = None
     service.save(update_fields=['status', 'employee'])
     return service
+
+
+def service_update_from_api(
+    *,
+    service: Service,
+    status: int = None,
+    end_date=None,
+    summary: str = None,
+) -> Service:
+    update_fields = []
+
+    if status is not None:
+        service.status = status
+        update_fields.append('status')
+
+    if end_date is not None:
+        service.end_date = end_date
+        update_fields.append('end_date')
+
+    if summary:
+        service.summary = (
+            f"{service.summary}\n{summary}".strip() if service.summary else summary
+        )
+        update_fields.append('summary')
+
+    if update_fields:
+        service.save(update_fields=update_fields)
+
+    return service


### PR DESCRIPTION
## Resumen

Esta PR cierra la **Fase 7 — API (DRF): ViewSets usan selectors + services** del plan SaaS multi-organización.

### Cambios principales
- Se refactorizaron los ViewSets DRF de `employee`, `service` y `client` para reducir acceso ORM directo desde la capa HTTP.
- Se agregó cobertura de contrato DRF para los endpoints que hoy consume el bot.
- Se cerró formalmente la fase con documentación, changelog e índice actualizados.

## Contexto técnico

El objetivo de esta fase fue alinear la API DRF con la decisión de arquitectura **D-004 (Selectors + Service Layer)**, de modo que la lógica de acceso a datos y mutaciones no quede dispersa dentro de los ViewSets.

Además, se preservó la decisión **D-002**: el endpoint `GET /api/employee/?chat_id=X` sigue siendo global porque es el bootstrap de autenticación del bot central.

## Cambios por archivo

| Archivo | Cambio |
|------|--------|
| `apis/employee/views.py` | `list`, `retrieve` y `update` ahora delegan en selectors/services y dejan de depender de queryset global abierto |
| `apis/employee/serializers.py` | agrega `organization_id` y `organization_slug` como campos de solo lectura |
| `apis/service/views.py` | `retrieve` usa selector y `partial_update` delega el append de `summary` al service layer |
| `apis/client/views.py` | se bloquea el listado global y `retrieve` usa selector |
| `employee/selectors.py` | agrega `get_employee_by_pk` |
| `client/selectors.py` | agrega `get_client_by_pk` |
| `service/selectors.py` | agrega `get_service_by_pk` |
| `service/services.py` | agrega `service_update_from_api` |
| `apis/tests.py` | cobertura DRF para employee, service y client |
| `docs/implementation-plan.md` | marca Fase 7 como completada |
| `docs/fase-7-api-drf.md` | documenta el cierre técnico de la fase |
| `docs/changelog.md` | agrega entrada de Fase 7 |
| `docs/README.md` | actualiza índice de documentación |

## Comportamiento validado

- `GET /api/employee/?chat_id=...` mantiene el flujo de bootstrap del bot.
- `GET /api/employee/?phone_number=...` resuelve empleados vía selector.
- `PUT /api/employee/<id>/` actualiza `chat_id` vía service layer.
- `GET /api/service/<id>/` deja de depender de queryset abierto.
- `PATCH /api/service/<id>/` conserva el append de `summary` pero movido a service layer.
- `GET /api/client/` ya no expone listado global accidental.

## Plan de pruebas

- [x] Ejecuté `source .venv/bin/activate && python manage.py test apis employee client service`
- [x] Validé que el suite terminó con **51 tests OK**
- [x] Verifiqué que la rama contiene commits atómicos separados para tests, implementación y documentación

## Notas

- Persisten warnings preexistentes en tests de `service` relacionados con corrutinas mockeadas (`send_msg` / `send_confirm_msg`), pero **no bloquean** el suite ni esta fase.
- La siguiente fase del plan es **Fase 8 — Bot central multi-org**.
