### PR TITLE
feat(bot): cerrar fase 8 multi-org para FTP y servicios

### DIFF
--- a/PhotosBot.py
+++ b/PhotosBot.py
@@ -62,24 +62,46 @@ def connect_ftp():
     return ftp
 
 
-# Función para verificar o crear una carpeta en FTP
-def create_ftp_folder(create_folder):
+# Función para verificar o crear una carpeta en FTP por organización
+def verify_or_create_ftp_folder(org_slug, folder_name):
     ftp = connect_ftp()
-    ftp.cwd(FTP_PATH)  # Ir a la ruta base
     try:
-        ftp.cwd(create_folder)  # Intentar entrar a la carpeta
+        ftp.cwd(f"{FTP_PATH}/{org_slug}")
     except ftplib.error_perm:
-        ftp.mkd(create_folder)  # Si no existe, crearla
+        ftp.mkd(f"{FTP_PATH}/{org_slug}")
+        ftp.cwd(f"{FTP_PATH}/{org_slug}")
+    try:
+        ftp.cwd(folder_name)
+    except ftplib.error_perm:
+        ftp.mkd(folder_name)
     ftp.quit()
 
 
 # Función para subir archivos a la NAS usando FTP
-def upload_a_ftp(local_name, remote_folder, remote_name):
+def upload_a_ftp(local_name, org_slug, remote_folder, remote_name):
     ftp = connect_ftp()
-    ftp.cwd(f"{FTP_PATH}/{remote_folder}")  # Entrar a la carpeta específica
+    ftp.cwd(f"{FTP_PATH}/{org_slug}/{remote_folder}")  # Entrar a la carpeta específica
     with open(local_name, "rb") as file:
         ftp.storbinary(f"STOR {remote_name}", file)
     ftp.quit()
+
+
+def build_service_folder(service):
+    service_number = service['service_number']
+    client_name = service['client']['first_name']
+    created_data = service['created_at'].split('T')[0]
+    return f"{service_number}-{client_name}-{created_data}"
+
+
+def build_active_service_entry(service):
+    org_slug = service.get('organization_slug') or service.get('employee', {}).get('organization_slug')
+    folder_name = build_service_folder(service)
+    return {
+        "service_id": service['id'],
+        "service_number": service['service_number'],
+        "org_slug": org_slug,
+        "folder": folder_name,
+    }
 
 
 # Comando para asignar el número de servicio y crear la carpeta en FTP
@@ -101,7 +123,6 @@ async def confirmButton(update: Update, context: ContextTypes.DEFAULT_TYPE):
             service_response = requests.patch(f"{API_URL}/service/{service['id']}/", data)
             service_response.raise_for_status()
             service = service_response.json()
-            print(service)
             messageConfirm = createMsgFromJson(service)
             await send_confirm_msg(messageConfirm, GROUP_CHAT_ID)
             await set_service(update, context, service)
@@ -120,18 +141,14 @@ async def confirmButton(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 async def set_service(update: Update, context: ContextTypes.DEFAULT_TYPE, service):
     chat_id = update.callback_query.message.chat_id
-    service_number = service['service_number']
-    client_name = service['client']['first_name']
-    created_data = service['created_at'].split('T')[0]
-
-    folder_name = f"{service_number}-{client_name}-{created_data}"
-    print(folder_name)
-    active_service[chat_id] = folder_name
+    service_context = build_active_service_entry(service)
+    folder_name = service_context['folder']
+    active_service[chat_id] = service_context
     # Crear la carpeta en el FTP si no existe
-    create_ftp_folder(folder_name)
+    verify_or_create_ftp_folder(service_context['org_slug'], folder_name)
 
     # Botón de finalizar servicio
-    keyboard = [[InlineKeyboardButton("✅ Finalizar Servicio", callback_data=f"finalizar_{folder_name}")]]
+    keyboard = [[InlineKeyboardButton("✅ Finalizar Servicio", callback_data=f"finalizar_{service_context['service_id']}")]]
     reply_markup = InlineKeyboardMarkup(keyboard)
 
     # Enviar mensaje de confirmación
@@ -150,8 +167,10 @@ async def manage_photos(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text("❌ No tienes un servicio activo.")
         return
 
-    service_folder = active_service[chat_id]
-    service_number = service_folder.split("-")[0]
+    service_context = active_service[chat_id]
+    service_folder = service_context['folder']
+    org_slug = service_context['org_slug']
+    service_id = service_context['service_id']
     archive = await update.message.photo[-1].get_file()
 
     # Crear el directorio file_temp si no existe
@@ -178,14 +197,14 @@ async def manage_photos(update: Update, context: ContextTypes.DEFAULT_TYPE):
     from asgiref.sync import sync_to_async
 
     try:
-        service = await sync_to_async(Service.objects.get)(pk=service_number)
+        service = await sync_to_async(Service.objects.get)(pk=service_id)
 
         with open(project_local_path, "rb") as f:
             django_file = File(f)
             # Crear ServiceImage de forma asíncrona
             service_image = await sync_to_async(ServiceImage.objects.create)(
                 service=service,
-                nas_url=f"{FTP_PATH}/{service_folder}"
+                nas_url=f"{FTP_PATH}/{org_slug}/{service_folder}"
             )
             # Guardar el archivo en el campo ImageField de forma asíncrona
             await sync_to_async(service_image.image.save)(image_filename, django_file)
@@ -203,7 +222,7 @@ async def manage_photos(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     # Subir a la carpeta del servicio en FTP
     try:
-        upload_a_ftp(local_name, service_folder, remote_name)
+        upload_a_ftp(local_name, org_slug, service_folder, remote_name)
         os.remove(local_name)
     except Exception as e:
         logging.error(f"Error uploading image to FTP: {e}")
@@ -212,11 +231,11 @@ async def manage_photos(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     # Eliminar el archivo local después de subirlo
 
-    keyboard = [[InlineKeyboardButton("✅ Finalizar Servicio", callback_data=f"finalizar_{service_number}")]]
+    keyboard = [[InlineKeyboardButton("✅ Finalizar Servicio", callback_data=f"finalizar_{service_id}")]]
     reply_markup = InlineKeyboardMarkup(keyboard)
 
     await update.message.reply_text(
-        f"📸 Imagen guardada en /Telegram/Bot/{service_number}",
+        f"📸 Imagen guardada en /Telegram/Bot/{service_folder}",
         reply_markup=reply_markup
     )
 
@@ -227,19 +246,19 @@ async def request_summary(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await query.answer()
 
     chat_id = query.message.chat_id
-    service_data = query.data.split("_")[1]
-    folder_name = service_data
-    service_number = service_data.split("-")[0]
+    service_id = int(query.data.split("_")[1])
 
     # Verificar que el usuario tenga el servicio asignado
-    if chat_id not in active_service or active_service[chat_id].split("-")[0] != service_number:
+    if chat_id not in active_service or active_service[chat_id]['service_id'] != service_id:
         await query.message.reply_text("❌ No tienes este servicio asignado.")
         return
 
+    service_context = active_service[chat_id]
     # Guardar la información del servicio para cuando envíe el resumen
     waiting_for_summary[chat_id] = {
-        'folder_name': folder_name,
-        'service_number': service_number
+        'folder_name': service_context['folder'],
+        'service_number': service_context['service_number'],
+        'service_id': service_id,
     }
 
     await query.message.reply_text("📝 Envía el resumen del servicio:")
@@ -256,16 +275,17 @@ async def handle_summary(update: Update, context: ContextTypes.DEFAULT_TYPE):
     service_info = waiting_for_summary[chat_id]
     folder_name = service_info['folder_name']
     service_number = service_info['service_number']
+    service_id = service_info['service_id']
 
     # Remover de la lista de espera
     del waiting_for_summary[chat_id]
 
     try:
-        response = requests.get(f"{API_URL}/service/{service_number}")
+        response = requests.get(f"{API_URL}/service/{service_id}")
         response.raise_for_status()
         service = response.json()
 
-        if chat_id in active_service and active_service[chat_id].split("-")[0] == service_number:
+        if chat_id in active_service and active_service[chat_id]['service_id'] == service_id:
             del active_service[chat_id]
             service['status'] = 2
             service['end_date'] = datetime.datetime.now(local_tz).strftime('%Y-%m-%d %H:%M:%S.%f')
@@ -277,7 +297,6 @@ async def handle_summary(update: Update, context: ContextTypes.DEFAULT_TYPE):
             service_response = requests.patch(f"{API_URL}/service/{service['id']}/", data)
             service_response.raise_for_status()
             service = service_response.json()
-            print(service)
             messageConfirm = createMsgFromJson(service)
             await send_confirm_msg(messageConfirm, GROUP_CHAT_ID)
             await update.message.reply_text(f"✅ Servicio {folder_name} finalizado con resumen.")
@@ -297,17 +316,16 @@ async def handle_summary(update: Update, context: ContextTypes.DEFAULT_TYPE):
 async def end_service_old(update: Update, context: ContextTypes.DEFAULT_TYPE):
     query = update.callback_query
     chat_id = query.message.chat_id
-    service_number = query.data.split("_")[1]
-    folder_name = service_number
-    service_number = service_number.split("-")[0]
+    service_id = int(query.data.split("_")[1])
+    folder_name = active_service.get(chat_id, {}).get('folder', str(service_id))
 
 
     try:
-        response = requests.get(f"{API_URL}/service/{service_number}")
+        response = requests.get(f"{API_URL}/service/{service_id}")
         response.raise_for_status()
         service = response.json()
 
-        if chat_id in active_service and active_service[chat_id].split("-")[0] == service_number:
+        if chat_id in active_service and active_service[chat_id]['service_id'] == service_id:
             del active_service[chat_id]
             service['status'] = 2
             service['end_date'] = datetime.datetime.now(local_tz).strftime('%Y-%m-%d %H:%M:%S.%f')
@@ -318,7 +336,6 @@ async def end_service_old(update: Update, context: ContextTypes.DEFAULT_TYPE):
             service_response = requests.patch(f"{API_URL}/service/{service['id']}/", data)
             service_response.raise_for_status()
             service = service_response.json()
-            print(service)
             messageConfirm = createMsgFromJson(service)
             await send_confirm_msg(messageConfirm, GROUP_CHAT_ID)
             await query.message.reply_text(f"✅ Servicio {folder_name} finalizado.")

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Este directorio contiene la documentación técnica del proyecto para que cualqu
 | [fase-5-selectors-service-layer.md](./fase-5-selectors-service-layer.md) | Fase 5 — Selectors + Service Layer |
 | [fase-6-vistas-web.md](./fase-6-vistas-web.md) | Fase 6 — Vistas web: delgadas, usan selectors + services |
 | [fase-7-api-drf.md](./fase-7-api-drf.md) | Fase 7 — API (DRF): ViewSets usan selectors + services |
+| [fase-8-bot-central-multi-org.md](./fase-8-bot-central-multi-org.md) | Fase 8 — Bot central multi-org |
 
 ## ¿Cómo usar estos docs?
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,43 @@ Registro de qué se implementó en cada fase y qué verificar antes de continuar
 
 ---
 
+## Fase 8 — Bot central multi-org
+
+**Fecha:** 2026-04-28
+**Rama:** `feat/fase-8-bot-central-multi-org`
+
+### Qué se implementó
+
+- `PhotosBot.py` ahora conserva contexto multi-org por chat activo: `service_id`, `service_number`, `org_slug` y `folder`
+- El bot dejó de usar `service_number` como identificador global para consultar y finalizar servicios; ahora usa `service_id`
+- La subida FTP ahora entra a `{FTP_PATH}/{org_slug}/{service_folder}`
+- `ServiceImage.nas_url` ahora incluye el prefijo de organización
+- Se agregaron tests unitarios para el flujo crítico del bot y helpers FTP
+
+### Qué probar
+
+```bash
+source .venv/bin/activate
+python manage.py test service.test_photos_bot apis service
+# Debe pasar con 33 tests OK
+
+# Verificación manual del flujo del bot:
+# 1. Inicia Django API
+python manage.py runserver
+
+# 2. En otra terminal, ejecuta el bot
+python PhotosBot.py
+
+# 3. Desde Telegram:
+#    - confirma un servicio
+#    - sube una foto
+#    - finaliza el servicio con resumen
+# 4. Verifica en FTP/NAS que la imagen quedó en:
+#    {FTP_PATH}/{org_slug}/{service_number}-{cliente}-{fecha}/
+```
+
+---
+
 ## Fase 7 — API (DRF): ViewSets usan selectors + services
 
 **Fecha:** 2026-04-28

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -97,3 +97,13 @@ Este archivo registra las decisiones de diseño tomadas para la conversión a Sa
 **Por qué no extender User:** `OneToOneField` es el patrón Django idiomático. Permite reusar `AUTH_USER_MODEL` sin modificarlo.
 
 **Acceso en views:** `request.user.profile.organization` (expuesto como `request.organization` desde `AdminRequiredMixin`).
+
+---
+
+## D-009: Estado del bot — Guardar `service_id` y `org_slug`
+
+**Decisión:** El estado en memoria del bot guarda `service_id`, `service_number`, `org_slug` y `folder` para cada chat activo.
+
+**Por qué:** Después de D-007, `service_number` ya NO es globalmente único. Si el bot usa solo el número de servicio para consultar la API o guardar imágenes, puede mezclar organizaciones distintas. `service_id` resuelve la identidad exacta y `org_slug` permite construir el path FTP aislado por organización.
+
+**Implicación:** El bot finaliza servicios por `service_id`, y `ServiceImage.nas_url` debe incluir `{FTP_PATH}/{org_slug}/{service_folder}`.

--- a/docs/fase-8-bot-central-multi-org.md
+++ b/docs/fase-8-bot-central-multi-org.md
@@ -1,0 +1,83 @@
+# Fase 8 — Bot central multi-org
+
+**Fecha:** 2026-04-28
+**Rama:** `feat/fase-8-bot-central-multi-org`
+
+## Objetivo
+
+Hacer que el bot central preserve el contexto de organización durante todo el flujo operativo: confirmación, subida de fotos, guardado de `nas_url` y finalización del servicio.
+
+## Qué se implementó
+
+### Contexto activo por chat
+
+- `PhotosBot.py`
+  - `active_service[chat_id]` dejó de ser un `str`
+  - ahora guarda:
+    - `service_id`
+    - `service_number`
+    - `org_slug`
+    - `folder`
+
+### Aislamiento FTP por organización
+
+- `verify_or_create_ftp_folder(org_slug, folder_name)`
+  - garantiza que exista la carpeta de organización antes de crear la carpeta del servicio
+
+- `upload_a_ftp(local_name, org_slug, remote_folder, remote_name)`
+  - sube archivos a `{FTP_PATH}/{org_slug}/{service_folder}`
+
+### Identidad correcta del servicio
+
+- el bot ya NO usa `service_number` para consultar `GET /api/service/<id>/` ni para finalizar servicios
+- ahora usa `service_id`, que sí es único globalmente
+- esto evita colisiones entre organizaciones donde `service_number=1` puede existir más de una vez
+
+### NAS URL multi-org
+
+- `ServiceImage.nas_url` ahora se guarda con el prefijo de organización:
+  - `{FTP_PATH}/{org_slug}/{service_folder}`
+
+## Archivos modificados
+
+| Archivo | Qué cambió |
+|---------|------------|
+| `PhotosBot.py` | estado multi-org por chat, lookup por `service_id`, FTP y `nas_url` con `org_slug` |
+| `service/test_photos_bot.py` | tests del flujo multi-org del bot y helpers FTP |
+| `docs/implementation-plan.md` | checkbox de Fase 8 marcado |
+| `docs/decisions.md` | decisión D-009 agregada |
+| `docs/changelog.md` | entrada de Fase 8 agregada |
+| `docs/README.md` | índice actualizado |
+
+## Qué probar
+
+```bash
+source .venv/bin/activate
+
+# Suite relevante de la fase
+python manage.py test service.test_photos_bot apis service
+
+# Flujo manual
+python manage.py runserver
+python PhotosBot.py
+```
+
+### Pasos manuales exactos
+
+1. En Telegram, confirma un servicio desde el botón enviado al empleado.
+2. Sube una foto al servicio activo.
+3. Finaliza el servicio y envía un resumen.
+4. Verifica que:
+   - la API no falló al consultar/finalizar el servicio
+   - el archivo quedó en `{FTP_PATH}/{org_slug}/{service_number}-{cliente}-{fecha}/`
+   - `ServiceImage.nas_url` incluye `org_slug`
+
+## Decisiones relevantes
+
+- **D-002:** sigue existiendo un solo bot central; el aislamiento se logra después del bootstrap del empleado.
+- **D-007:** `service_number` es único por organización, no globalmente.
+- **D-009:** el estado del bot debe guardar `service_id` y `org_slug` para evitar mezclar tenants.
+
+## Siguiente fase
+
+[Fase 9 — Panel super-admin para gestión de organizaciones](./implementation-plan.md#fase-9--panel-super-admin-para-gestión-de-organizaciones)

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -27,7 +27,7 @@ Si eres un agente retomando este trabajo:
 - [x] Fase 5 — Selectors + Service Layer
 - [x] Fase 6 — Vistas web: delgadas, usan selectors + services
 - [x] Fase 7 — API (DRF): ViewSets usan selectors + services
-- [ ] Fase 8 — Bot central multi-org
+- [x] Fase 8 — Bot central multi-org
 - [ ] Fase 9 — Panel super-admin para gestión de organizaciones
 
 ---

--- a/service/test_photos_bot.py
+++ b/service/test_photos_bot.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+from unittest import IsolatedAsyncioTestCase, TestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import PhotosBot
+
+
+class PhotosBotStateTest(IsolatedAsyncioTestCase):
+    def setUp(self):
+        PhotosBot.active_service.clear()
+        PhotosBot.waiting_for_summary.clear()
+
+    async def test_set_service_stores_service_id_org_slug_and_folder(self):
+        reply_text = AsyncMock()
+        update = SimpleNamespace(
+            callback_query=SimpleNamespace(
+                message=SimpleNamespace(chat_id=321, reply_text=reply_text)
+            )
+        )
+        service = {
+            "id": 77,
+            "service_number": 5,
+            "created_at": "2026-04-28T12:00:00Z",
+            "client": {"first_name": "Cliente Demo"},
+            "employee": {"organization_slug": "org-a"},
+        }
+
+        with patch("PhotosBot.verify_or_create_ftp_folder") as verify_folder:
+            await PhotosBot.set_service(update, SimpleNamespace(), service)
+
+        self.assertEqual(
+            PhotosBot.active_service[321],
+            {
+                "service_id": 77,
+                "service_number": 5,
+                "org_slug": "org-a",
+                "folder": "5-Cliente Demo-2026-04-28",
+            },
+        )
+        verify_folder.assert_called_once_with("org-a", "5-Cliente Demo-2026-04-28")
+        reply_text.assert_awaited()
+
+    async def test_handle_summary_fetches_service_by_service_id_not_service_number(self):
+        chat_id = 321
+        PhotosBot.active_service[chat_id] = {
+            "service_id": 77,
+            "service_number": 5,
+            "org_slug": "org-a",
+            "folder": "5-Cliente Demo-2026-04-28",
+        }
+        PhotosBot.waiting_for_summary[chat_id] = {
+            "service_id": 77,
+            "service_number": 5,
+            "folder_name": "5-Cliente Demo-2026-04-28",
+        }
+        reply_text = AsyncMock()
+        update = SimpleNamespace(
+            message=SimpleNamespace(
+                chat_id=chat_id,
+                text="Trabajo terminado",
+                reply_text=reply_text,
+            )
+        )
+
+        get_response = MagicMock()
+        get_response.raise_for_status.return_value = None
+        get_response.json.return_value = {"id": 77, "service_number": 5}
+
+        patch_response = MagicMock()
+        patch_response.raise_for_status.return_value = None
+        patch_response.json.return_value = {
+            "id": 77,
+            "service_number": 5,
+            "client": {"first_name": "Cliente Demo"},
+            "employee": {"first_name": "Ana"},
+            "description": "desc",
+            "status_name": "Finalizado",
+        }
+
+        with (
+            patch("PhotosBot.requests.get", return_value=get_response) as mock_get,
+            patch("PhotosBot.requests.patch", return_value=patch_response) as mock_patch,
+            patch("PhotosBot.send_confirm_msg", new=AsyncMock()) as send_confirm,
+        ):
+            await PhotosBot.handle_summary(update, SimpleNamespace())
+
+        mock_get.assert_called_once_with(f"{PhotosBot.API_URL}/service/77")
+        mock_patch.assert_called_once()
+        self.assertNotIn(chat_id, PhotosBot.active_service)
+        self.assertNotIn(chat_id, PhotosBot.waiting_for_summary)
+        send_confirm.assert_awaited_once()
+        reply_text.assert_awaited_once()
+
+
+class PhotosBotFtpHelpersTest(TestCase):
+    def test_upload_a_ftp_uses_org_slug_prefix(self):
+        ftp = MagicMock()
+
+        with (
+            patch("PhotosBot.connect_ftp", return_value=ftp),
+            patch("builtins.open", MagicMock()),
+        ):
+            PhotosBot.upload_a_ftp("/tmp/demo.jpg", "org-a", "5-demo-2026-04-28", "demo.jpg")
+
+        ftp.cwd.assert_called_once_with(f"{PhotosBot.FTP_PATH}/org-a/5-demo-2026-04-28")
+
+    def test_verify_or_create_ftp_folder_creates_org_folder_before_service_folder(self):
+        ftp = MagicMock()
+        ftp.cwd.side_effect = [Exception("base missing"), None, Exception("service missing")]
+
+        with patch("PhotosBot.connect_ftp", return_value=ftp):
+            with patch("PhotosBot.ftplib.error_perm", Exception):
+                PhotosBot.verify_or_create_ftp_folder("org-a", "5-demo-2026-04-28")
+
+        ftp.mkd.assert_any_call(f"{PhotosBot.FTP_PATH}/org-a")
+        ftp.mkd.assert_any_call("5-demo-2026-04-28")


### PR DESCRIPTION
Closes #6

## Tipo de PR
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Resumen
- Cierra la Fase 8 del plan SaaS para que el bot opere correctamente en un esquema multi-organización.
- Corrige la identidad operativa del bot usando `service_id` en lugar de `service_number` para consultas y finalización.
- Aísla FTP/NAS por organización y deja la fase documentada con pruebas automatizadas y documentación de cierre.

## Contexto y problema
Después de la migración multi-org, `service_number` dejó de ser globalmente único. El bot todavía asumía lo contrario y además construía rutas FTP sin namespace por organización. Eso abría dos riesgos arquitectónicos: consultar/finalizar el servicio equivocado y mezclar imágenes entre tenants.

## Cambios realizados

### 1. Flujo multi-org en el bot
- `PhotosBot.py`
  - `active_service[chat_id]` ahora guarda `service_id`, `service_number`, `org_slug` y `folder`.
  - el bot usa `service_id` para consultar y finalizar servicios.
  - se agrega `verify_or_create_ftp_folder(org_slug, folder_name)` para crear o reutilizar la carpeta de la organización antes de la del servicio.
  - `upload_a_ftp(...)` ahora sube a `{FTP_PATH}/{org_slug}/{service_folder}`.
  - `ServiceImage.nas_url` se guarda con prefijo de organización.

### 2. Cobertura automatizada
- `service/test_photos_bot.py`
  - cobertura para almacenamiento de contexto activo multi-org
  - cobertura para finalización por `service_id`
  - cobertura para helpers FTP con carpeta de organización y carpeta de servicio

### 3. Cierre documental de fase
- se marca la Fase 8 como completada en `docs/implementation-plan.md`
- se agrega `docs/fase-8-bot-central-multi-org.md`
- se actualizan `docs/changelog.md`, `docs/README.md` y `docs/decisions.md`
- se documenta la decisión **D-009** sobre el estado mínimo correcto del bot en modo multi-tenant

## Tabla de cambios
| Archivo | Cambio |
|------|--------|
| `PhotosBot.py` | Contexto activo multi-org, lookup por `service_id`, FTP/NAS con `org_slug` |
| `service/test_photos_bot.py` | Tests del flujo multi-org del bot y helpers FTP |
| `docs/implementation-plan.md` | Checkbox de Fase 8 marcado |
| `docs/fase-8-bot-central-multi-org.md` | Documento de cierre de la fase |
| `docs/changelog.md` | Registro de cambios y pasos de prueba |
| `docs/README.md` | Índice actualizado |
| `docs/decisions.md` | Nueva decisión D-009 |

## Plan de pruebas
- [x] Tests ejecutados: `python manage.py test service.test_photos_bot apis service`
- [x] Validación funcional del flujo FTP multi-org mediante tests unitarios
- [x] Documentación actualizada para reflejar comportamiento y cierre de fase
- [ ] Verificación manual pendiente en entorno con bot + FTP real

## Qué validar manualmente
```bash
source .venv/bin/activate
python manage.py runserver
python PhotosBot.py
```

Pasos:
1. Confirmar un servicio desde Telegram.
2. Subir una foto.
3. Finalizar el servicio con resumen.
4. Verificar que el archivo quedó en:
   `{FTP_PATH}/{org_slug}/{service_number}-{cliente}-{fecha}/`

## Riesgos y tradeoffs
- Se mantuvo el formato actual de nombre de carpeta del servicio (`{service_number}-{cliente}-{fecha}`) para no romper el flujo visible actual.
- Como mejora futura conviene sanitizar el nombre del cliente para evitar caracteres problemáticos en algunos servidores FTP.

## Checklist del contribuidor
- [x] Issue vinculado y aprobado
- [x] Se agregó exactamente una label `type:*`
- [x] Commits en formato convencional
- [x] Documentación actualizada
- [x] Sin trailers `Co-Authored-By`
- [x] Tests relevantes ejecutados
