### PR TITLE
feat(organization): add super-admin organization panel

### DIFF
--- a/BotPhotosSYMT/urls.py
+++ b/BotPhotosSYMT/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     path('', include('service.urls')),
     path('employee/', include('employee.urls')),
     path('client/', include('client.urls')),
+    path('organizations/', include('organization.urls')),
 ]
 
 urlpatterns +=[

--- a/common/views.py
+++ b/common/views.py
@@ -13,3 +13,12 @@ class AdminRequiredMixin(AccessMixin):
         except Exception:
             raise PermissionDenied("Tu usuario no tiene una organización asignada.")
         return super().dispatch(request, *args, **kwargs)
+
+
+class SuperAdminRequiredMixin(AccessMixin):
+    def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return self.handle_no_permission()
+        if not request.user.is_superuser:
+            raise PermissionDenied("Solo el super-admin puede acceder.")
+        return super().dispatch(request, *args, **kwargs)

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ Este directorio contiene la documentación técnica del proyecto para que cualqu
 | [fase-6-vistas-web.md](./fase-6-vistas-web.md) | Fase 6 — Vistas web: delgadas, usan selectors + services |
 | [fase-7-api-drf.md](./fase-7-api-drf.md) | Fase 7 — API (DRF): ViewSets usan selectors + services |
 | [fase-8-bot-central-multi-org.md](./fase-8-bot-central-multi-org.md) | Fase 8 — Bot central multi-org |
+| [fase-9-panel-super-admin.md](./fase-9-panel-super-admin.md) | Fase 9 — Panel super-admin para gestión de organizaciones |
 
 ## ¿Cómo usar estos docs?
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,41 @@
 
 Registro de qué se implementó en cada fase y qué verificar antes de continuar a la siguiente.
 
+## Fase 9 — Panel super-admin para gestión de organizaciones
+
+**Fecha:** 2026-04-28
+**Rama:** `feat/fase-9-panel-super-admin`
+
+### Qué se implementó
+
+- Nuevo panel web bajo `/organizations/` protegido por `is_superuser`
+- CRUD operativo de la fase: listar, crear, editar nombre, ver detalle, activar/desactivar y asignar usuarios existentes
+- `SuperAdminRequiredMixin` agregado para centralizar autorización del panel
+- Slug de organización generado automáticamente y con resolución de colisiones
+- El detalle muestra miembros y resumen operativo por organización
+- La edición permite cambiar el nombre sin alterar el `slug`
+- La asignación de usuarios bloquea perfiles ya vinculados a otra organización
+- Se agregaron tests del panel y validaciones de acceso
+
+### Qué probar
+
+```bash
+source .venv/bin/activate
+python manage.py test organization employee client service apis
+# Debe pasar con 70 tests OK
+
+python manage.py runserver
+# Verificar manualmente:
+# - /organizations/
+# - /organizations/create/
+# - /organizations/<slug>/
+# - /organizations/<slug>/edit/
+# - toggle de estado
+# - asignación de usuario sin organización
+```
+
+---
+
 ---
 
 ## Fase 8 — Bot central multi-org

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -107,3 +107,21 @@ Este archivo registra las decisiones de diseño tomadas para la conversión a Sa
 **Por qué:** Después de D-007, `service_number` ya NO es globalmente único. Si el bot usa solo el número de servicio para consultar la API o guardar imágenes, puede mezclar organizaciones distintas. `service_id` resuelve la identidad exacta y `org_slug` permite construir el path FTP aislado por organización.
 
 **Implicación:** El bot finaliza servicios por `service_id`, y `ServiceImage.nas_url` debe incluir `{FTP_PATH}/{org_slug}/{service_folder}`.
+
+
+## D-010: Panel super-admin — asignación solo a usuarios sin organización
+
+**Decisión:** El panel super-admin permite asignar usuarios existentes solo si aún NO tienen `UserProfile`. No se permite reasignar usuarios entre organizaciones desde esta fase.
+
+**Por qué:** Reduce el riesgo de mover miembros entre tenants por error desde un panel operativo simple. La reasignación implica una decisión administrativa más delicada y queda fuera del MVP de esta fase.
+
+**Implicación:** El formulario de asignación lista únicamente usuarios sin organización y, si se intenta forzar un usuario ya vinculado, la operación se rechaza con mensaje claro.
+
+
+## D-011: Edición de organizaciones — el slug permanece estable
+
+**Decisión:** La edición de organización en el panel super-admin permite cambiar solo el `name`. El `slug` NO se regenera ni se edita desde UI.
+
+**Por qué:** El slug ya participa en rutas y paths operativos; cambiarlo rompe referencias y contradice la decisión de usarlo como identificador estable.
+
+**Implicación:** La vista de edición muestra el slug como referencia de solo lectura y la escritura se limita al nombre.

--- a/docs/fase-9-panel-super-admin.md
+++ b/docs/fase-9-panel-super-admin.md
@@ -1,0 +1,106 @@
+# Fase 9 — Panel super-admin para gestión de organizaciones
+
+**Fecha:** 2026-04-28
+**Rama:** `feat/fase-9-panel-super-admin`
+
+## Objetivo
+
+Agregar un panel web exclusivo para `is_superuser` que permita administrar organizaciones del SaaS: listarlas, crearlas, editarlas, ver su detalle operativo, activar/desactivar y asignar usuarios existentes sin organización.
+
+## Qué se implementó
+
+### Protección por superusuario
+
+- `common/views.py`
+  - nuevo `SuperAdminRequiredMixin`
+  - permite acceso solo a usuarios autenticados con `is_superuser=True`
+
+### Panel de organizaciones
+
+- `organization/views.py`
+  - `OrganizationListView` para listar organizaciones con conteos rápidos
+  - `OrganizationCreateView` para crear organizaciones con slug auto-generado
+  - `OrganizationDetailView` para mostrar miembros y resumen operativo
+  - `OrganizationUpdateView` para editar el nombre sin cambiar el slug
+  - `OrganizationToggleView` para activar/desactivar
+  - `OrganizationAssignUserView` para asignar usuarios existentes
+
+- `organization/urls.py`
+  - nuevas rutas bajo `/organizations/`
+
+- `BotPhotosSYMT/urls.py`
+  - inclusión del módulo `organization.urls`
+
+### Formularios, lectura y escritura
+
+- `organization/forms.py`
+  - formulario de creación de organización
+  - formulario de edición de organización
+  - formulario de asignación de usuario
+
+- `organization/selectors.py`
+  - lecturas del panel: listado, detalle, miembros y stats
+
+- `organization/services.py`
+  - creación de organización con slug único
+  - edición del nombre conservando el slug
+  - toggle de `is_active`
+  - asignación de usuario con bloqueo si ya pertenece a otra organización
+
+### Navegación y templates
+
+- `templates/sidebar.html`
+  - enlace a Organizaciones visible solo para superusuarios
+
+- `organization/templates/`
+  - `org_list.html`
+  - `org_create.html`
+  - `org_edit.html`
+  - `org_detail.html`
+
+## Tabla de campos
+
+No se agregaron campos nuevos ni migraciones en esta fase.
+
+## Qué probar
+
+```bash
+source .venv/bin/activate
+
+# Suite relevante de la fase
+python manage.py test organization employee client service apis
+
+# Verificación manual
+python manage.py runserver
+```
+
+### Pasos manuales exactos
+
+1. Inicia sesión con un superusuario.
+2. Entra a `http://localhost:8000/organizations/`.
+3. Verifica que se muestren organizaciones con estado y conteos.
+4. Crea una organización nueva desde `http://localhost:8000/organizations/create/`.
+5. Edita la organización creada desde su listado o detalle y confirma que:
+   - cambia el nombre
+   - el `slug` NO cambia
+6. Abre el detalle de la organización creada y confirma que se vean:
+   - slug
+   - miembros
+   - total de servicios
+   - activos/asignados
+   - finalizados
+   - empleados
+   - clientes
+7. Usa el botón de activar/desactivar y confirma que cambie el estado.
+8. Asigna un usuario existente SIN organización y confirma que se crea su `UserProfile`.
+9. Intenta asignar un usuario que ya pertenece a otra organización y confirma que la operación se rechaza.
+
+## Decisiones relevantes
+
+- **D-003:** solo el super-admin puede crear organizaciones.
+- **D-008:** la vinculación usuario ↔ organización sigue viviendo en `UserProfile`.
+- **D-010:** desde este panel solo se asignan usuarios sin organización; no hay reasignación entre tenants en esta fase.
+
+## Siguiente fase
+
+Plan maestro completado hasta la Fase 9 actual.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -28,7 +28,7 @@ Si eres un agente retomando este trabajo:
 - [x] Fase 6 — Vistas web: delgadas, usan selectors + services
 - [x] Fase 7 — API (DRF): ViewSets usan selectors + services
 - [x] Fase 8 — Bot central multi-org
-- [ ] Fase 9 — Panel super-admin para gestión de organizaciones
+- [x] Fase 9 — Panel super-admin para gestión de organizaciones
 
 ---
 
@@ -517,7 +517,9 @@ class SuperAdminRequiredMixin(AccessMixin):
 - `GET /organizations/` — listar organizaciones + estado
 - `GET /organizations/create/` — formulario crear org (name, slug auto-generado)
 - `GET /organizations/<slug>/` — detalle: miembros, stats de servicios
+- `GET /organizations/<slug>/edit/` — formulario para editar nombre de la organización
+- `POST /organizations/<slug>/edit/` — actualizar nombre manteniendo el slug
 - `POST /organizations/<slug>/toggle/` — activar/desactivar org
 - `POST /organizations/<slug>/assign-user/` — asignar user existente a la org
 
-**Verificación:** Login con superuser, verificar CRUD completo de organizaciones.
+**Verificación:** Login con superuser, verificar listado, creación, edición de nombre, detalle, toggle y asignación de usuarios.

--- a/organization/forms.py
+++ b/organization/forms.py
@@ -1,0 +1,34 @@
+from django import forms
+from django.contrib.auth.models import User
+
+from .models import Organization
+
+
+class OrganizationCreateForm(forms.ModelForm):
+    class Meta:
+        model = Organization
+        fields = ['name']
+        labels = {
+            'name': 'Nombre de la organización',
+        }
+
+
+class OrganizationUpdateForm(forms.ModelForm):
+    class Meta:
+        model = Organization
+        fields = ['name']
+        labels = {
+            'name': 'Nombre de la organización',
+        }
+
+
+class AssignUserToOrganizationForm(forms.Form):
+    user = forms.ModelChoiceField(
+        queryset=User.objects.none(),
+        label='Usuario',
+        empty_label='Selecciona un usuario',
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['user'].queryset = User.objects.filter(profile__isnull=True).order_by('username')

--- a/organization/selectors.py
+++ b/organization/selectors.py
@@ -1,0 +1,45 @@
+from django.contrib.auth.models import User
+from django.db.models import Count, Q
+from django.shortcuts import get_object_or_404
+
+from .models import Organization, UserProfile
+from service.models import Service
+
+
+ACTIVE_ASSIGNED_STATUSES = [
+    Service.Status.Active,
+    Service.Status.Assigned,
+    Service.Status.Reassigned,
+]
+
+
+def get_organizations_with_summary():
+    return Organization.objects.annotate(
+        members_count=Count('members', distinct=True),
+        employees_count=Count('employees', distinct=True),
+        clients_count=Count('clients', distinct=True),
+        services_count=Count('services', distinct=True),
+    ).order_by('name')
+
+
+def get_organization_by_slug(*, slug: str) -> Organization:
+    return get_object_or_404(Organization, slug=slug)
+
+
+def get_organization_members(*, organization: Organization):
+    return UserProfile.objects.filter(organization=organization).select_related('user').order_by('user__username')
+
+
+def get_organization_stats(*, organization: Organization) -> dict:
+    services = organization.services.all()
+    return {
+        'total_services': services.count(),
+        'active_assigned_services': services.filter(status__in=ACTIVE_ASSIGNED_STATUSES).count(),
+        'finished_services': services.filter(status=Service.Status.Cancelled).count(),
+        'employees_count': organization.employees.count(),
+        'clients_count': organization.clients.count(),
+    }
+
+
+def get_unassigned_users():
+    return User.objects.filter(profile__isnull=True).order_by('username')

--- a/organization/services.py
+++ b/organization/services.py
@@ -1,0 +1,44 @@
+from django.contrib.auth.models import User
+from django.db import transaction
+from django.utils.text import slugify
+
+from .models import Organization, UserProfile
+
+
+@transaction.atomic
+def organization_create(*, name: str) -> Organization:
+    base_slug = slugify(name)
+    slug = base_slug
+    suffix = 1
+
+    while Organization.objects.filter(slug=slug).exists():
+        slug = f'{base_slug}-{suffix}'
+        suffix += 1
+
+    organization = Organization(name=name, slug=slug)
+    organization.full_clean()
+    organization.save()
+    return organization
+
+
+@transaction.atomic
+def organization_update_name(*, organization: Organization, name: str) -> Organization:
+    organization.name = name
+    organization.full_clean()
+    organization.save(update_fields=['name', 'updated_at'])
+    return organization
+
+
+@transaction.atomic
+def organization_toggle_active(*, organization: Organization) -> Organization:
+    organization.is_active = not organization.is_active
+    organization.save(update_fields=['is_active', 'updated_at'])
+    return organization
+
+
+@transaction.atomic
+def organization_assign_user(*, organization: Organization, user: User) -> UserProfile:
+    if hasattr(user, 'profile'):
+        raise ValueError('El usuario ya tiene una organización asignada.')
+
+    return UserProfile.objects.create(user=user, organization=organization)

--- a/organization/templates/org_create.html
+++ b/organization/templates/org_create.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-8 col-lg-6">
+    <div class="card">
+      <div class="card-body">
+        <h4 class="card-title mb-3">Crear organización</h4>
+        <p class="text-muted">El slug se genera automáticamente a partir del nombre.</p>
+
+        <form method="post">
+          {% csrf_token %}
+          <div class="mb-3">
+            <label for="id_name" class="form-label">{{ organization_form.name.label }}</label>
+            {{ organization_form.name }}
+            {% if organization_form.name.errors %}
+              <div class="text-danger small mt-1">{{ organization_form.name.errors|join:', ' }}</div>
+            {% endif %}
+          </div>
+          <div class="d-flex justify-content-end gap-2">
+            <a href="{% url 'organization_list' %}" class="btn btn-light">Cancelar</a>
+            <button type="submit" class="btn btn-primary">Crear</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/organization/templates/org_detail.html
+++ b/organization/templates/org_detail.html
@@ -1,0 +1,85 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+  <div>
+    <h4 class="mb-1">{{ organization.name }}</h4>
+    <p class="text-muted mb-0">Slug: {{ organization.slug }}</p>
+  </div>
+  <div class="d-flex gap-2">
+    <a href="{% url 'organization_edit' organization.slug %}" class="btn btn-outline-secondary">Editar</a>
+    <form method="post" action="{% url 'organization_toggle' organization.slug %}">
+      {% csrf_token %}
+      {% if organization.is_active %}
+        <button type="submit" class="btn btn-warning">Desactivar</button>
+      {% else %}
+        <button type="submit" class="btn btn-success">Activar</button>
+      {% endif %}
+    </form>
+  </div>
+</div>
+
+<div class="row">
+  <div class="col-lg-8">
+    <div class="card mb-4">
+      <div class="card-body">
+        <h5 class="card-title">Resumen operativo</h5>
+        <div class="row g-3">
+          <div class="col-md-4"><div class="border rounded p-3"><strong>Total servicios:</strong> {{ stats.total_services }}</div></div>
+          <div class="col-md-4"><div class="border rounded p-3"><strong>Activos/asignados:</strong> {{ stats.active_assigned_services }}</div></div>
+          <div class="col-md-4"><div class="border rounded p-3"><strong>Finalizados:</strong> {{ stats.finished_services }}</div></div>
+          <div class="col-md-6"><div class="border rounded p-3"><strong>Empleados:</strong> {{ stats.employees_count }}</div></div>
+          <div class="col-md-6"><div class="border rounded p-3"><strong>Clientes:</strong> {{ stats.clients_count }}</div></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">Miembros</h5>
+        <div class="table-responsive">
+          <table class="table align-middle">
+            <thead>
+              <tr>
+                <th>Usuario</th>
+                <th>Email</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for member in members %}
+              <tr>
+                <td>{{ member.user.username }}</td>
+                <td>{{ member.user.email|default:'—' }}</td>
+              </tr>
+              {% empty %}
+              <tr>
+                <td colspan="2" class="text-center text-muted">Sin miembros asignados.</td>
+              </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-lg-4">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">Asignar usuario</h5>
+        <form method="post" action="{% url 'organization_assign_user' organization.slug %}">
+          {% csrf_token %}
+          <div class="mb-3">
+            <label for="id_user" class="form-label">{{ assign_user_form.user.label }}</label>
+            {{ assign_user_form.user }}
+            {% if assign_user_form.user.errors %}
+              <div class="text-danger small mt-1">{{ assign_user_form.user.errors|join:', ' }}</div>
+            {% endif %}
+          </div>
+          <button type="submit" class="btn btn-primary w-100">Asignar</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/organization/templates/org_edit.html
+++ b/organization/templates/org_edit.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="row justify-content-center">
+  <div class="col-md-8 col-lg-6">
+    <div class="card">
+      <div class="card-body">
+        <h4 class="card-title mb-3">Editar organización</h4>
+        <p class="text-muted mb-1">Slug actual: <strong>{{ organization.slug }}</strong></p>
+        <p class="text-muted">El slug se conserva para no romper referencias existentes.</p>
+
+        <form method="post">
+          {% csrf_token %}
+          <div class="mb-3">
+            <label for="id_name" class="form-label">{{ organization_form.name.label }}</label>
+            {{ organization_form.name }}
+            {% if organization_form.name.errors %}
+              <div class="text-danger small mt-1">{{ organization_form.name.errors|join:', ' }}</div>
+            {% endif %}
+          </div>
+          <div class="d-flex justify-content-end gap-2">
+            <a href="{% url 'organization_detail' organization.slug %}" class="btn btn-light">Cancelar</a>
+            <button type="submit" class="btn btn-primary">Guardar cambios</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/organization/templates/org_list.html
+++ b/organization/templates/org_list.html
@@ -1,0 +1,61 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="card">
+  <div class="card-body">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+      <div>
+        <h4 class="card-title mb-1">Organizaciones</h4>
+        <p class="text-muted mb-0">Panel exclusivo para super-admin.</p>
+      </div>
+      <a href="{% url 'organization_create' %}" class="btn btn-primary">Nueva organización</a>
+    </div>
+
+    <div class="table-responsive">
+      <table class="table align-middle">
+        <thead>
+          <tr>
+            <th>Nombre</th>
+            <th>Slug</th>
+            <th>Estado</th>
+            <th>Miembros</th>
+            <th>Empleados</th>
+            <th>Clientes</th>
+            <th>Servicios</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for organization in organizations %}
+          <tr>
+            <td>{{ organization.name }}</td>
+            <td>{{ organization.slug }}</td>
+            <td>
+              {% if organization.is_active %}
+                <span class="badge bg-success">Activa</span>
+              {% else %}
+                <span class="badge bg-danger">Inactiva</span>
+              {% endif %}
+            </td>
+            <td>{{ organization.members_count }}</td>
+            <td>{{ organization.employees_count }}</td>
+            <td>{{ organization.clients_count }}</td>
+            <td>{{ organization.services_count }}</td>
+            <td class="text-end">
+              <div class="d-flex justify-content-end gap-2">
+                <a href="{% url 'organization_edit' organization.slug %}" class="btn btn-sm btn-outline-secondary">Editar</a>
+                <a href="{% url 'organization_detail' organization.slug %}" class="btn btn-sm btn-outline-primary">Ver detalle</a>
+              </div>
+            </td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td colspan="8" class="text-center text-muted">No hay organizaciones registradas.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/organization/tests.py
+++ b/organization/tests.py
@@ -1,5 +1,11 @@
+from django.contrib.auth.models import Group, User
 from django.test import TestCase
-from django.contrib.auth.models import User
+from django.urls import reverse
+from django.utils.text import slugify
+
+from client.models import Client
+from employee.models import Employee
+from service.models import Service
 
 from .models import Organization, UserProfile
 
@@ -27,3 +33,153 @@ class UserProfileModelTest(TestCase):
         UserProfile.objects.create(user=self.user, organization=self.org)
         self.org.delete()
         self.assertEqual(UserProfile.objects.filter(user=self.user).count(), 0)
+
+
+class OrganizationPanelAccessTest(TestCase):
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username="root",
+            email="root@example.com",
+            password="pass1234",
+        )
+        self.regular_user = User.objects.create_user(username="regular", password="pass1234")
+        admin_group, _ = Group.objects.get_or_create(name="admin")
+        self.regular_user.groups.add(admin_group)
+        self.organization = Organization.objects.create(name="Org Uno", slug="org-uno")
+        UserProfile.objects.create(user=self.regular_user, organization=self.organization)
+
+    def test_organization_list_redirects_anonymous_to_login(self):
+        response = self.client.get(reverse('organization_list'))
+        self.assertEqual(response.status_code, 302)
+        self.assertIn('/login/', response.url)
+
+    def test_organization_list_denies_non_superuser(self):
+        self.client.force_login(self.regular_user)
+        response = self.client.get(reverse('organization_list'))
+        self.assertEqual(response.status_code, 403)
+
+    def test_organization_list_allows_superuser(self):
+        self.client.force_login(self.superuser)
+        response = self.client.get(reverse('organization_list'))
+        self.assertEqual(response.status_code, 200)
+
+
+class OrganizationPanelViewTest(TestCase):
+    def setUp(self):
+        self.superuser = User.objects.create_superuser(
+            username="root",
+            email="root@example.com",
+            password="pass1234",
+        )
+        self.client.force_login(self.superuser)
+
+        self.organization = Organization.objects.create(name="Org Uno", slug="org-uno")
+        self.other_organization = Organization.objects.create(name="Org Dos", slug="org-dos")
+
+        self.member = User.objects.create_user(username="member", password="pass1234")
+        UserProfile.objects.create(user=self.member, organization=self.organization)
+        self.free_user = User.objects.create_user(username="free-user", password="pass1234")
+        self.taken_user = User.objects.create_user(username="taken-user", password="pass1234")
+        UserProfile.objects.create(user=self.taken_user, organization=self.other_organization)
+
+        self.client_obj = Client.objects.create(first_name="Cliente", organization=self.organization)
+        self.employee = Employee.objects.create(
+            first_name="Empleado",
+            last_name="Uno",
+            phone_number="5551231234",
+            organization=self.organization,
+        )
+        Service.objects.create(
+            organization=self.organization,
+            client=self.client_obj,
+            service_title="Creado",
+            service_number=1,
+            status=Service.Status.Creating,
+        )
+        Service.objects.create(
+            organization=self.organization,
+            client=self.client_obj,
+            service_title="Asignado",
+            service_number=2,
+            status=Service.Status.Assigned,
+        )
+        Service.objects.create(
+            organization=self.organization,
+            client=self.client_obj,
+            service_title="Finalizado",
+            service_number=3,
+            status=Service.Status.Cancelled,
+        )
+
+    def test_organization_list_shows_organizations(self):
+        response = self.client.get(reverse('organization_list'))
+        self.assertContains(response, 'Org Uno')
+        self.assertContains(response, 'Org Dos')
+
+    def test_organization_create_generates_unique_slug(self):
+        response = self.client.post(reverse('organization_create'), {'name': 'Org Uno'})
+        self.assertEqual(response.status_code, 302)
+        new_org = Organization.objects.exclude(pk=self.organization.pk).get(name='Org Uno')
+        self.assertEqual(new_org.slug, 'org-uno-1')
+
+    def test_organization_edit_page_loads(self):
+        response = self.client.get(reverse('organization_edit', args=[self.organization.slug]))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Editar organización')
+        self.assertContains(response, self.organization.slug)
+
+    def test_organization_edit_updates_name_and_keeps_slug(self):
+        response = self.client.post(
+            reverse('organization_edit', args=[self.organization.slug]),
+            {'name': 'Org Uno Editada'},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.organization.refresh_from_db()
+        self.assertEqual(self.organization.name, 'Org Uno Editada')
+        self.assertEqual(self.organization.slug, 'org-uno')
+
+    def test_organization_detail_shows_operational_stats(self):
+        response = self.client.get(reverse('organization_detail', args=[self.organization.slug]))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['stats']['total_services'], 3)
+        self.assertEqual(response.context['stats']['active_assigned_services'], 1)
+        self.assertEqual(response.context['stats']['finished_services'], 1)
+        self.assertEqual(response.context['stats']['employees_count'], 1)
+        self.assertEqual(response.context['stats']['clients_count'], 1)
+
+    def test_organization_toggle_switches_active_flag(self):
+        response = self.client.post(reverse('organization_toggle', args=[self.organization.slug]))
+        self.assertEqual(response.status_code, 302)
+        self.organization.refresh_from_db()
+        self.assertFalse(self.organization.is_active)
+
+    def test_organization_assign_user_creates_profile_for_free_user(self):
+        response = self.client.post(
+            reverse('organization_assign_user', args=[self.organization.slug]),
+            {'user': self.free_user.pk},
+        )
+        self.assertEqual(response.status_code, 302)
+        profile = UserProfile.objects.get(user=self.free_user)
+        self.assertEqual(profile.organization, self.organization)
+
+    def test_organization_assign_user_rejects_taken_user(self):
+        response = self.client.post(
+            reverse('organization_assign_user', args=[self.organization.slug]),
+            {'user': self.taken_user.pk},
+        )
+        self.assertEqual(response.status_code, 302)
+        self.taken_user.refresh_from_db()
+        self.assertEqual(self.taken_user.profile.organization, self.other_organization)
+
+    def test_assign_user_form_only_lists_users_without_profile(self):
+        response = self.client.get(reverse('organization_detail', args=[self.organization.slug]))
+        form = response.context['assign_user_form']
+        queryset_ids = set(form.fields['user'].queryset.values_list('id', flat=True))
+        self.assertIn(self.free_user.id, queryset_ids)
+        self.assertNotIn(self.member.id, queryset_ids)
+        self.assertNotIn(self.taken_user.id, queryset_ids)
+
+
+class OrganizationFormBehaviorTest(TestCase):
+    def test_slugify_reference_behavior(self):
+        self.assertEqual(slugify('Mi Organización Nueva'), 'mi-organizacion-nueva')

--- a/organization/urls.py
+++ b/organization/urls.py
@@ -1,0 +1,19 @@
+from django.urls import path
+
+from .views import (
+    OrganizationAssignUserView,
+    OrganizationCreateView,
+    OrganizationDetailView,
+    OrganizationListView,
+    OrganizationToggleView,
+    OrganizationUpdateView,
+)
+
+urlpatterns = [
+    path('', OrganizationListView.as_view(), name='organization_list'),
+    path('create/', OrganizationCreateView.as_view(), name='organization_create'),
+    path('<slug:slug>/edit/', OrganizationUpdateView.as_view(), name='organization_edit'),
+    path('<slug:slug>/', OrganizationDetailView.as_view(), name='organization_detail'),
+    path('<slug:slug>/toggle/', OrganizationToggleView.as_view(), name='organization_toggle'),
+    path('<slug:slug>/assign-user/', OrganizationAssignUserView.as_view(), name='organization_assign_user'),
+]

--- a/organization/views.py
+++ b/organization/views.py
@@ -1,0 +1,128 @@
+from django.contrib import messages
+from django.contrib.auth.models import User
+from django.shortcuts import redirect
+from django.views import View
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+
+from common.views import SuperAdminRequiredMixin
+
+from .forms import AssignUserToOrganizationForm, OrganizationCreateForm, OrganizationUpdateForm
+from .selectors import (
+    get_organization_by_slug,
+    get_organization_members,
+    get_organization_stats,
+    get_organizations_with_summary,
+)
+from .services import (
+    organization_assign_user,
+    organization_create,
+    organization_toggle_active,
+    organization_update_name,
+)
+
+
+class OrganizationListView(SuperAdminRequiredMixin, ListView):
+    template_name = 'org_list.html'
+    context_object_name = 'organizations'
+
+    def get_queryset(self):
+        return get_organizations_with_summary()
+
+
+class OrganizationCreateView(SuperAdminRequiredMixin, CreateView):
+    template_name = 'org_create.html'
+    form_class = OrganizationCreateForm
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['organization_form'] = kwargs.get('form') or OrganizationCreateForm()
+        return context
+
+    def post(self, request, *args, **kwargs):
+        form = OrganizationCreateForm(request.POST)
+        if form.is_valid():
+            organization = organization_create(name=form.cleaned_data['name'])
+            messages.success(request, 'Organización creada con éxito.')
+            return redirect('organization_detail', slug=organization.slug)
+        return self.render_to_response(self.get_context_data(form=form))
+
+
+class OrganizationUpdateView(SuperAdminRequiredMixin, UpdateView):
+    template_name = 'org_edit.html'
+    form_class = OrganizationUpdateForm
+    context_object_name = 'organization'
+
+    def get_object(self):
+        return get_organization_by_slug(slug=self.kwargs['slug'])
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['organization_form'] = kwargs.get('form') or OrganizationUpdateForm(instance=self.get_object())
+        return context
+
+    def post(self, request, *args, **kwargs):
+        organization = self.get_object()
+        form = OrganizationUpdateForm(request.POST, instance=organization)
+        if form.is_valid():
+            organization_update_name(
+                organization=organization,
+                name=form.cleaned_data['name'],
+            )
+            messages.success(request, 'Organización actualizada con éxito.')
+            return redirect('organization_detail', slug=organization.slug)
+        return self.render_to_response(self.get_context_data(form=form))
+
+
+class OrganizationDetailView(SuperAdminRequiredMixin, DetailView):
+    template_name = 'org_detail.html'
+    context_object_name = 'organization'
+
+    def get_object(self):
+        return get_organization_by_slug(slug=self.kwargs['slug'])
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        organization = self.get_object()
+        context['stats'] = get_organization_stats(organization=organization)
+        context['members'] = get_organization_members(organization=organization)
+        context['assign_user_form'] = kwargs.get('assign_user_form') or AssignUserToOrganizationForm()
+        return context
+
+
+class OrganizationToggleView(SuperAdminRequiredMixin, View):
+    def post(self, request, slug):
+        organization = get_organization_by_slug(slug=slug)
+        organization_toggle_active(organization=organization)
+        state = 'activada' if organization.is_active else 'desactivada'
+        messages.success(request, f'Organización {state} con éxito.')
+        return redirect('organization_detail', slug=organization.slug)
+
+
+class OrganizationAssignUserView(SuperAdminRequiredMixin, View):
+    def post(self, request, slug):
+        organization = get_organization_by_slug(slug=slug)
+        form = AssignUserToOrganizationForm(request.POST)
+        if form.is_valid():
+            user = form.cleaned_data['user']
+            try:
+                organization_assign_user(organization=organization, user=user)
+            except ValueError as exc:
+                messages.error(request, str(exc))
+            else:
+                messages.success(request, 'Usuario asignado con éxito.')
+            return redirect('organization_detail', slug=organization.slug)
+
+        submitted_user_id = request.POST.get('user')
+        if submitted_user_id:
+            user = User.objects.filter(pk=submitted_user_id).first()
+            if user and hasattr(user, 'profile'):
+                messages.error(request, 'El usuario ya tiene una organización asignada.')
+                return redirect('organization_detail', slug=organization.slug)
+
+        messages.error(request, 'Selecciona un usuario disponible para asignar.')
+        detail_view = OrganizationDetailView()
+        detail_view.setup(request, slug=slug)
+        detail_view.object = organization
+        return detail_view.render_to_response(
+            detail_view.get_context_data(assign_user_form=form)
+        )

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -41,6 +41,16 @@
                 <span class="hide-menu">Clientes</span>
               </a>
             </li>
+            {% if request.user.is_superuser %}
+            <li class="sidebar-item">
+              <a class="sidebar-link" href="{% url 'organization_list' %}" aria-expanded="false">
+                <span>
+                  <i class="ti ti-building"></i>
+                </span>
+                <span class="hide-menu">Organizaciones</span>
+              </a>
+            </li>
+            {% endif %}
           </ul>
         </nav>
         <!-- End Sidebar navigation -->


### PR DESCRIPTION
Closes #8

## Tipo de PR
- [x] New feature
- [ ] Bug fix
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Resumen

- Se implementó la Fase 9 del plan SaaS con un panel web exclusivo para superusuarios para gestionar organizaciones.
- Se agregó soporte para listar, crear, editar nombre, ver detalle, activar/desactivar y asignar usuarios existentes sin organización.
- Se documentó el cierre de fase y se formalizaron las decisiones D-010 y D-011 para proteger el aislamiento multi-organización.

## Contexto

Esta fase continúa la migración de `symt-services` hacia un modelo SaaS multi-organización.
Después de cerrar el aislamiento de datos en modelos, vistas, API y bot central, faltaba el panel operativo para que el super-admin pudiera administrar organizaciones desde la web sin romper las decisiones arquitectónicas previas.

## Qué se hizo

### 1. Autorización para super-admin
Se agregó un mixin dedicado para proteger el panel de organizaciones:

- `common/views.py`
  - nuevo `SuperAdminRequiredMixin`
  - permite acceso solo a usuarios autenticados con `is_superuser=True`

Esto evita mezclar permisos del admin operativo por organización con permisos globales del dueño del sistema.

### 2. Panel de organizaciones
Se agregó un módulo web completo bajo `/organizations/`:

- `GET /organizations/`
  - lista organizaciones con estado y conteos rápidos
- `GET /organizations/create/`
  - formulario para crear organización
- `GET /organizations/<slug>/`
  - detalle de organización con miembros y resumen operativo
- `GET /organizations/<slug>/edit/`
  - formulario para editar organización
- `POST /organizations/<slug>/edit/`
  - actualiza el nombre manteniendo el slug
- `POST /organizations/<slug>/toggle/`
  - activa/desactiva la organización
- `POST /organizations/<slug>/assign-user/`
  - asigna usuarios existentes sin organización

### 3. Creación y edición de organizaciones
Se implementó lógica dedicada para evitar meter reglas de negocio en la view:

- `organization/forms.py`
  - `OrganizationCreateForm`
  - `OrganizationUpdateForm`
  - `AssignUserToOrganizationForm`

- `organization/services.py`
  - `organization_create()`
  - `organization_update_name()`
  - `organization_toggle_active()`
  - `organization_assign_user()`

#### Regla importante
La edición **NO** cambia el `slug`.

Esto se hizo a propósito porque el `slug` ya funciona como identificador estable en rutas y referencias operativas. Regenerarlo al editar el nombre habría sido una mala decisión técnica.

### 4. Selectors para lecturas del panel
Se agregaron lecturas dedicadas en:

- `organization/selectors.py`

Incluye:
- listado con resumen
- lookup por slug
- miembros de la organización
- estadísticas operativas

### 5. Resumen operativo por organización
En el detalle se muestran métricas útiles para operación:

- total de servicios
- servicios activos/asignados
- servicios finalizados
- total de empleados
- total de clientes
- miembros vinculados por `UserProfile`

### 6. Asignación de usuarios sin romper tenants
La asignación de usuarios quedó restringida a usuarios que **no tienen `UserProfile`**.

Si un usuario ya pertenece a otra organización:
- no aparece en el selector
- y si se intenta forzar la asignación, se rechaza

Esto protege el aislamiento entre organizaciones y evita mover usuarios entre tenants desde un panel simple.

### 7. Navegación
Se actualizó la navegación para mostrar acceso al panel solo a superusuarios:

- `templates/sidebar.html`

### 8. Templates nuevos
Se agregaron vistas específicas para el panel:

- `organization/templates/org_list.html`
- `organization/templates/org_create.html`
- `organization/templates/org_edit.html`
- `organization/templates/org_detail.html`

### 9. Cobertura de pruebas
Se agregaron y actualizaron tests para cubrir:

- acceso de superuser
- bloqueo a no superusers
- creación de organización con slug único
- edición del nombre manteniendo slug
- detalle con estadísticas correctas
- toggle de estado
- asignación válida de usuario sin organización
- rechazo de usuario ya asignado

## Cambios por archivo

| File | Change |
|------|--------|
| `common/views.py` | Nuevo `SuperAdminRequiredMixin` |
| `BotPhotosSYMT/urls.py` | Inclusión de rutas de `organization` |
| `organization/forms.py` | Formularios de creación, edición y asignación |
| `organization/selectors.py` | Lecturas del panel y stats |
| `organization/services.py` | Lógica de creación, edición, toggle y asignación |
| `organization/views.py` | Views del panel super-admin |
| `organization/urls.py` | Rutas `/organizations/` |
| `organization/templates/org_list.html` | Listado de organizaciones |
| `organization/templates/org_create.html` | Formulario de creación |
| `organization/templates/org_edit.html` | Formulario de edición |
| `organization/templates/org_detail.html` | Detalle con miembros y métricas |
| `organization/tests.py` | Cobertura del panel y edición |
| `templates/sidebar.html` | Enlace visible solo para superusuarios |
| `docs/implementation-plan.md` | Cierre/actualización de Fase 9 |
| `docs/decisions.md` | Nuevas decisiones D-010 y D-011 |
| `docs/changelog.md` | Registro de la fase |
| `docs/README.md` | Índice actualizado |
| `docs/fase-9-panel-super-admin.md` | Documento de cierre de fase |

## Decisiones técnicas relevantes

- **D-003**: solo el super-admin puede crear organizaciones
- **D-008**: la relación usuario ↔ organización sigue en `UserProfile`
- **D-010**: el panel solo asigna usuarios sin organización
- **D-011**: la edición de organización conserva el `slug`

## Commits incluidos

- `test: add organization panel coverage`
- `feat: add super-admin organization panel`
- `docs: close phase 9 organization panel`

## Plan de pruebas

- [x] Ejecutado: `python manage.py test organization employee client service apis`
- [x] Resultado: `72 tests OK`
- [x] Validado flujo de creación, edición, toggle y asignación mediante tests
- [x] Documentación actualizada para la fase

## Pruebas manuales sugeridas

```bash
source .venv/bin/activate
python manage.py runserver
```

Verificar:

1. login con superusuario
2. `/organizations/`
3. creación de organización
4. edición del nombre sin cambiar slug
5. detalle con miembros y resumen operativo
6. activar/desactivar organización
7. asignación de usuario sin organización
8. rechazo de usuario ya vinculado a otra organización

## Checklist

- [x] Linked an approved issue
- [ ] Added exactly one `type:*` label
- [x] Docs updated if behavior changed
- [x] Conventional commit format used
- [x] No `Co-Authored-By` trailers
